### PR TITLE
Add/cpp style callbacks

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -6347,141 +6347,80 @@ void Audio::performAudioTask() {
 
 void Audio::call_audio_info(const char* info) {
     if (audio_info) audio_info(info);
-
-    if(this->audioInfoCallback) {
-        std::string s(info);
-        this->audioInfoCallback(s);
-    }
+    if(this->audioInfoCallback) this->audioInfoCallback(info);
 }
 
 void Audio::call_audio_id3data(const char* info) {
     if (audio_id3data) audio_id3data(info);
-
-    if (this->id3DataCallback) {
-        std::string s(info);
-        this->id3DataCallback(s);
-    }
+    if (this->id3DataCallback) this->id3DataCallback(info);
 }
 
 void Audio::call_audio_id3image(File& file, const size_t pos, const size_t size) {
     if (audio_id3image) audio_id3image(file, pos, size);
-
-    if (this->id3ImageCallback) {
-        this->id3ImageCallback(file, pos, size);
-    }
+    if (this->id3ImageCallback) this->id3ImageCallback(file, pos, size);
 }
 
 void Audio::call_audio_oggimage(File& file, std::vector<uint32_t> v) {
     if (audio_oggimage) audio_oggimage(file, v);
-
-    if (this->oggImageCallback) {
-        this->oggImageCallback(file, v);
-    }
+    if (this->oggImageCallback) this->oggImageCallback(file, v);
 }
 
 void Audio::call_audio_id3lyrics(File& file, const size_t pos, const size_t size) {
     if (audio_id3lyrics) audio_id3lyrics(file, pos, size);
-
-    if (this->id3LyricsCallback) {
-        this->id3LyricsCallback(file, pos, size);
-    }
+    if (this->id3LyricsCallback) this->id3LyricsCallback(file, pos, size);
 }
 
 void Audio::call_audio_eof_mp3(const char* info) {
     if (audio_eof_mp3) audio_eof_mp3(info)
-
-    if (this->mp3EOFCallback) {
-        std::string s(info);
-        this->mp3EOFCallback(s);
-    }
+    if (this->mp3EOFCallback) this->mp3EOFCallback(info);
 }
 
 void Audio::call_audio_showstreamtitle(const char* info) {
     if (audio_showstreamtitle) audio_showstreamtitle(info);
-
-    if (this->streamTitleCallback) {
-        std::string s(info);
-        this->streamTitleCallback(s);
-    }
+    if (this->streamTitleCallback) this->streamTitleCallback(info);
 }
 
 void Audio::call_audio_showstation(const char* info) {
     if (audio_showstation) audio_showstation(info);
-
-    if (this->stationNameCallback) {
-        std::string s(info);
-        this->stationNameCallback(s);
-    }
+    if (this->stationNameCallback) this->stationNameCallback(info);
 }
 
 void Audio::call_audio_bitrate(const char* info) {
     if (audio_bitrate) audio_bitrate(info);
-
-    if (this->bitrateChangeCallback) {
-        std::string s(info);
-        this->bitrateChangeCallback(s);
-    }
+    if (this->bitrateChangeCallback) this->bitrateChangeCallback(info);
 }
 
 void Audio::call_audio_commercial(const char* info) {
     if (audio_commercial) audio_commercial(info);
-
-    if (this->commercialInfoCallback) {
-        std::string s(info);
-        this->commercialInfoCallback(s);
-    }
+    if (this->commercialInfoCallback) this->commercialInfoCallback(info);
 }
 
 void Audio::call_audio_icyurl(const char* info) {
     if (audio_icyurl) audio_icyurl(info);
-
-    if (this->icyUrlCallback) {
-        std::string s(info);
-        this->icyUrlCallback(s);
-    }
+    if (this->icyUrlCallback) this->icyUrlCallback(info);
 }
 
 void Audio::call_audio_icylogo(const char* info) {
     if (audio_icylogo) audio_icylogo(info);
-
-    if (this->icyLogoCallback) {
-        std::string s(info);
-        this->icyLogoCallback(s);
-    }
+    if (this->icyLogoCallback) this->icyLogoCallback(info);
 }
 
 void Audio::call_audio_icydescription(const char* info) {
     if (audio_icydescription) audio_icydescription(info);
-
-    if (this->icyDescriptionCallback) {
-        std::string s(info);
-        this->icyDescriptionCallback(s);
-    }
+    if (this->icyDescriptionCallback) this->icyDescriptionCallback(info);
 }
 
 void Audio::call_audio_lasthost(const char* info) {
     if (audio_lasthost) audio_lasthost(info);
-
-    if (this->lastHostCallback) {
-        std::string s(info);
-        this->lastHostCallback(s);
-    }
+    if (this->lastHostCallback) this->lastHostCallback(info);
 }
 
 void Audio::call_audio_eof_speech(const char* info) {
     if (audio_eof_speech) audio_eof_speech(info);
-
-    if (this->speechEOFCallback) {
-        std::string s(info);
-        this->speechEOFCallback(s);
-    }
+    if (this->speechEOFCallback) this->speechEOFCallback(info);
 }
 
 void Audio::call_audio_eof_stream(const char* info) {
     if (audio_eof_stream) audio_eof_stream(info);
-
-    if (this->streamEOFCallback) {
-        std::string s(info);
-        this->streamEOFCallback(s);
-    }
+    if (this->streamEOFCallback) this->streamEOFCallback(info);
 }

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -200,7 +200,7 @@ Audio::Audio(bool internalDAC /* = false */, uint8_t channelEnabled /* = I2S_SLO
 #define AUDIO_INFO(...)                     \
     {                                       \
         snprintf(m_ibuff, m_ibuffSize, __VA_ARGS__);      \
-        if(audio_info) audio_info(m_ibuff); \
+        this->call_audio_info(m_ibuff); \
     }
 
     clientsecure.setInsecure();
@@ -647,17 +647,17 @@ bool Audio::connecttohost(const char* host, const char* user, const char* pwd) {
         if(endsWith(h_host, ".pls" )) m_expectedPlsFmt = FORMAT_PLS;
         if(endsWith(h_host, ".m3u8")) {
             m_expectedPlsFmt = FORMAT_M3U8;
-            if(audio_lasthost) audio_lasthost(host);
+            this->call_audio_lasthost(host);
         }
         m_dataMode = HTTP_RESPONSE_HEADER; // Handle header
         m_streamType = ST_WEBSTREAM;
     }
     else {
         AUDIO_INFO("Request %s failed!", host);
-        if(audio_showstation) audio_showstation("");
-        if(audio_showstreamtitle) audio_showstreamtitle("");
-        if(audio_icydescription) audio_icydescription("");
-        if(audio_icyurl) audio_icyurl("");
+        this->call_audio_showstation("");
+        this->call_audio_showstreamtitle("");
+        this->call_audio_icydescription("");
+        this->call_audio_icyurl("");
         m_lastHost[0] = 0;
     }
 
@@ -1023,7 +1023,7 @@ void Audio::showID3Tag(const char* tag, const char* value) {
         return;
     }
     if(m_chbuf[0] != 0) {
-        if(audio_id3data) audio_id3data(m_chbuf);
+        this->call_audio_id3data(m_chbuf);
     }
 }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1442,7 +1442,7 @@ int Audio::read_FLAC_Header(uint8_t* data, size_t len) {
         FLACSetRawBlockParams(m_flacNumChannels, m_flacSampleRate, m_flacBitsPerSample, m_flacTotalSamplesInStream, m_audioDataSize);
         if(picLen) {
             size_t pos = audiofile.position();
-            if(audio_id3image) audio_id3image(audiofile, picPos, picLen);
+            this->call_audio_id3image(audiofile, picPos, picLen);
             audiofile.seek(pos); // the filepointer could have been changed by the user, set it back
         }
         AUDIO_INFO("Audio-Length: %u", m_audioDataSize);
@@ -1526,7 +1526,7 @@ int Audio::read_FLAC_Header(uint8_t* data, size_t len) {
         strcpy(m_chbuf, "VENDOR_STRING: ");
         strncpy(m_chbuf + 15, (const char*)data, vendorStringLength);
         m_chbuf[15 + vendorStringLength] = '\0';
-        if(audio_id3data) audio_id3data(m_chbuf);
+        this->call_audio_id3data(m_chbuf);
         data += vendorStringLength; idx += vendorStringLength;
         size_t commentListLength = data[0] + (data[1] << 8) + (data[2] << 16) + (data[3] << 24);
         data += 4; idx += 4;
@@ -1538,7 +1538,7 @@ int Audio::read_FLAC_Header(uint8_t* data, size_t len) {
             if(commentLength < 512) { // guard
                 strncpy(m_chbuf, (const char *)data , commentLength);
                 m_chbuf[commentLength] = '\0';
-                if(audio_id3data) audio_id3data(m_chbuf);
+                this->call_audio_id3data(m_chbuf);
             }
             data += commentLength; idx += commentLength;
             if(idx > vendorLength + 3) {log_e("VORBIS COMMENT section is too long");}
@@ -1858,14 +1858,14 @@ int Audio::read_ID3_Header(uint8_t* data, size_t len) {
             m_controlCounter = 100; // ok
             m_audioDataSize = m_contentlength - m_audioDataStart;
             if(!m_f_m3u8data) AUDIO_INFO("Audio-Length: %u", m_audioDataSize);
-            if(APIC_pos[0] && audio_id3image) { // if we have more than one APIC, output the first only
+            if(APIC_pos[0]) { // if we have more than one APIC, output the first only
                 size_t pos = audiofile.position();
-                audio_id3image(audiofile, APIC_pos[0], APIC_size[0]);
+                this->call_audio_id3image(audiofile, APIC_pos[0], APIC_size[0]);
                 audiofile.seek(pos); // the filepointer could have been changed by the user, set it back
             }
-            if(SYLT_seen && audio_id3lyrics) {
+            if(SYLT_seen) {
                 size_t pos = audiofile.position();
-                audio_id3lyrics(audiofile, SYLT_pos, SYLT_size);
+                this->call_audio_id3lyrics(audiofile, SYLT_pos, SYLT_size);
                 audiofile.seek(pos); // the filepointer could have been changed by the user, set it back
             }
             numID3Header = 0;
@@ -2139,7 +2139,7 @@ int Audio::read_M4A_Header(uint8_t* data, size_t len) {
                     if(i == 10) sprintf(m_chbuf, "Album Artist: %s", value);
                     if(i == 11) sprintf(m_chbuf, "Types of: %s", value);
                     if(m_chbuf[0] != 0) {
-                        if(audio_id3data) audio_id3data(m_chbuf);
+                        this->call_audio_id3data(m_chbuf);
                     }
                 }
             }
@@ -2183,7 +2183,7 @@ int Audio::read_M4A_Header(uint8_t* data, size_t len) {
         }
         if(picLen) {
             size_t pos = audiofile.position();
-            audio_id3image(audiofile, picPos, picLen);
+            this->call_audio_id3image(audiofile, picPos, picLen);
             audiofile.seek(pos); // the filepointer could have been changed by the user, set it back
         }
         m_controlCounter = M4A_OKAY; // that's all
@@ -2646,7 +2646,7 @@ const char* Audio::parsePlaylist_PLS() {
         }
         if(startsWith(m_playlistContent[i], "Title1")) { // Title1=Antenne Tirol
             const char* plsStationName = (m_playlistContent[i] + 7);
-            if(audio_showstation) audio_showstation(plsStationName);
+            this->call_audio_showstation(plsStationName);
             AUDIO_INFO("StationName: \"%s\"", plsStationName);
             continue;
         }
@@ -2695,7 +2695,7 @@ const char* Audio::parsePlaylist_ASX() { // Advanced Stream Redirector
             if(pos >= 0) {
                 *(plsStationName + pos) = 0; // remove </Title>
             }
-            if(audio_showstation) audio_showstation(plsStationName);
+            this->call_audio_showstation(plsStationName);
             AUDIO_INFO("StationName: \"%s\"", plsStationName);
         }
 
@@ -3220,7 +3220,7 @@ log_w("");
         if(m_codec == CODEC_VORBIS) VORBISDecoder_FreeBuffers();
 
         if(afn) {
-            if(audio_eof_mp3) audio_eof_mp3(afn);
+            this->call_audio_eof_mp3(afn);
             AUDIO_INFO("End of file \"%s\"", afn);
             free(afn);
             afn = NULL;
@@ -3389,11 +3389,11 @@ void Audio::processWebFile() {
         m_codec = CODEC_NONE;
         if(m_f_tts) {
             AUDIO_INFO("End of speech: \"%s\"", m_lastHost);
-            if(audio_eof_speech) audio_eof_speech(m_lastHost);
+            this->call_audio_eof_speech(m_lastHost);
         }
         else {
             AUDIO_INFO("End of webstream: \"%s\"", m_lastHost);
-            if(audio_eof_stream) audio_eof_stream(m_lastHost);
+            this->call_audio_eof_stream(m_lastHost);
         }
         return;
     }
@@ -3745,7 +3745,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
             statusCode[3] = '\0';
             int sc = atoi(statusCode);
             if(sc > 310) { // e.g. HTTP/1.1 301 Moved Permanently
-                if(audio_showstreamtitle) audio_showstreamtitle(rhl);
+                this->call_audio_showstreamtitle(rhl);
                 goto exit;
             }
         }
@@ -3817,7 +3817,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
             trim(c_icylogo);
             if(strlen(c_icylogo) > 0) {
                 if(m_f_Log) AUDIO_INFO("icy-logo: %s", c_icylogo);
-                if(audio_icylogo) audio_icylogo(c_icylogo);
+                this->call_audio_icylogo(c_icylogo);
             }
         }
 
@@ -3827,7 +3827,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
             br = br * 1000;
             setBitrate(br);
             sprintf(m_chbuf, "%lu", (long unsigned int)getBitRate());
-            if(audio_bitrate) audio_bitrate(m_chbuf);
+            this->call_audio_bitrate(m_chbuf);
         }
 
         else if(startsWith(rhl, "icy-metaint:")) {
@@ -3842,7 +3842,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
             trim(c_icyname);
             if(strlen(c_icyname) > 0) {
                 if(m_f_Log) AUDIO_INFO("icy-name: %s", c_icyname);
-                if(audio_showstation) audio_showstation(c_icyname);
+                this->call_audio_showstation(c_icyname);
             }
         }
 
@@ -3862,7 +3862,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
                 AUDIO_INFO("icy-description: %s has to be 8 or 16", c_idesc);
                 stopSong();
             }
-            if(audio_icydescription) audio_icydescription(c_idesc);
+            this->call_audio_icydescription(c_idesc);
         }
 
         else if(startsWith(rhl, "transfer-encoding:")) {
@@ -3876,7 +3876,7 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
         else if(startsWith(rhl, "icy-url:")) {
             char* icyurl = (rhl + 8);
             trim(icyurl);
-            if(audio_icyurl) audio_icyurl(icyurl);
+            this->call_audio_icyurl(icyurl);
         }
 
         else if(startsWith(rhl, "www-authenticate:")) {
@@ -3887,9 +3887,9 @@ bool Audio::parseHttpResponseHeader() { // this is the response to a GET / reque
     } // outer while
 
 exit: // termination condition
-    if(audio_showstation) audio_showstation("");
-    if(audio_icydescription) audio_icydescription("");
-    if(audio_icyurl) audio_icyurl("");
+    this->call_audio_showstation("");
+    this->call_audio_icydescription("");
+    this->call_audio_icyurl("");
     if(m_playlistFormat == FORMAT_M3U8) return false;
 //    m_lastHost[0] = '\0';
     m_dataMode = AUDIO_NONE;
@@ -3901,7 +3901,7 @@ lastToDo:
         m_dataMode = AUDIO_DATA; // Expecting data now
         if(!initializeDecoder()) return false;
         if(m_f_Log) { log_i("Switch to DATA, metaint is %d", m_metaint); }
-        if(m_playlistFormat != FORMAT_M3U8 && audio_lasthost) audio_lasthost(m_lastHost);
+        if(m_playlistFormat != FORMAT_M3U8) this->call_audio_lasthost(m_lastHost);
         m_controlCounter = 0;
         m_f_firstCall = true;
     }
@@ -4188,7 +4188,7 @@ void Audio::showstreamtitle(const char* ml) {
                 }
                 if(m_streamTitleHash != hash) {
                     m_streamTitleHash = hash;
-                    if(audio_showstreamtitle) audio_showstreamtitle(title);
+                    this->call_audio_showstreamtitle(title);
                 }
                 free(title);
                 title = NULL;
@@ -4219,7 +4219,7 @@ void Audio::showstreamtitle(const char* ml) {
             uint8_t pos = 12;                                                 // remove "StreamTitle="
             if(sTit[pos] == '\'') pos++;                                      // remove leading  \'
             if(sTit[strlen(sTit) - 1] == '\'') sTit[strlen(sTit) - 1] = '\0'; // remove trailing \'
-            if(audio_showstreamtitle) audio_showstreamtitle(sTit + pos);
+            this->call_audio_showstreamtitle(sTit + pos);
         }
         if(sTit) {
             free(sTit);
@@ -4262,7 +4262,7 @@ void Audio::showstreamtitle(const char* ml) {
             uint8_t pos = 21;                                                 // remove "StreamTitle="
             if(sAdv[pos] == '\'') pos++;                                      // remove leading  \'
             if(sAdv[strlen(sAdv) - 1] == '\'') sAdv[strlen(sAdv) - 1] = '\0'; // remove trailing \'
-            if(audio_commercial) audio_commercial(sAdv + pos);
+            this->call_audio_commercial(sAdv + pos);
             if(sAdv) {
                 free(sAdv);
                 sAdv = NULL;
@@ -4334,19 +4334,19 @@ int Audio::findNextSync(uint8_t* data, size_t len) {
         if(nextSync == -1) return len; // OggS not found, search next block
     }
     if(nextSync == -1) {
-        if(audio_info && swnf == 0) audio_info("syncword not found");
+        if(swnf == 0) this->call_audio_info("syncword not found");
         else {
             swnf++; // syncword not found counter, can be multimediadata
         }
     }
     if(nextSync == 0) {
-        if(audio_info && swnf > 0) {
+        if(swnf > 0) {
             sprintf(m_chbuf, "syncword not found %lu times", (long unsigned int)swnf);
-            audio_info(m_chbuf);
+            this->call_audio_info(m_chbuf);
             swnf = 0;
         }
         else {
-            if(audio_info) audio_info("syncword found at pos 0");
+            this->call_audio_info("syncword found at pos 0");
         }
     }
     if(nextSync > 0) { AUDIO_INFO("syncword found at pos %i", nextSync); }
@@ -4468,7 +4468,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
     bytesDecoded = len - bytesLeft;
 
     if(bytesDecoded == 0 && m_decodeError == 0) { // unlikely framesize
-        if(audio_info) audio_info("framesize is 0, start decoding again");
+        this->call_audio_info("framesize is 0, start decoding again");
         m_f_playing = false; // seek for new syncword
         // we're here because there was a wrong sync word so skip one byte and seek for the next
         return 1;
@@ -4498,7 +4498,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                             st = FLACgetStreamTitle();
                             if(st) {
                                 AUDIO_INFO(st);
-                                if(audio_showstreamtitle) audio_showstreamtitle(st);
+                                this->call_audio_showstreamtitle(st);
                             }
                             vec = FLACgetMetadataBlockPicture();
                             if(vec.size() > 0){ // get blockpic data
@@ -4506,7 +4506,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                                 // log_i("ogg metadata blockpicture found:");
                                 // for(int i = 0; i < vec.size(); i += 2) { log_i("segment %02i, pos %07i, len %05i", i / 2, vec[i], vec[i + 1]); }
                                 // log_i("---------------------------------------------------------------------------");
-                                if(audio_oggimage) audio_oggimage(audiofile, vec);
+                                this->call_audio_oggimage(audiofile, vec);
                             }
                             break;
         case CODEC_OPUS:    if(m_decodeError == OPUS_PARSE_OGG_DONE) return bytesDecoded; // nothing to play
@@ -4514,7 +4514,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                             st = OPUSgetStreamTitle();
                             if(st){
                                 AUDIO_INFO(st);
-                                if(audio_showstreamtitle) audio_showstreamtitle(st);
+                                this->call_audio_showstreamtitle(st);
                             }
                             vec = OPUSgetMetadataBlockPicture();
                             if(vec.size() > 0){ // get blockpic data
@@ -4522,7 +4522,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                                 // log_i("ogg metadata blockpicture found:");
                                 // for(int i = 0; i < vec.size(); i += 2) { log_i("segment %02i, pos %07i, len %05i", i / 2, vec[i], vec[i + 1]); }
                                 // log_i("---------------------------------------------------------------------------");
-                                if(audio_oggimage) audio_oggimage(audiofile, vec);
+                                this->call_audio_oggimage(audiofile, vec);
                             }
                             break;
         case CODEC_VORBIS:  if(m_decodeError == VORBIS_PARSE_OGG_DONE) return bytesDecoded; // nothing to play
@@ -4530,7 +4530,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                             st = VORBISgetStreamTitle();
                             if(st) {
                                 AUDIO_INFO(st);
-                                if(audio_showstreamtitle) audio_showstreamtitle(st);
+                                this->call_audio_showstreamtitle(st);
                             }
                             vec = VORBISgetMetadataBlockPicture();
                             if(vec.size() > 0){ // get blockpic data
@@ -4538,7 +4538,7 @@ int Audio::sendBytes(uint8_t* data, size_t len) {
                                 // log_i("ogg metadata blockpicture found:");
                                 // for(int i = 0; i < vec.size(); i += 2) { log_i("segment %02i, pos %07i, len %05i", i / 2, vec[i], vec[i + 1]); }
                                 // log_i("---------------------------------------------------------------------------");
-                                if(audio_oggimage) audio_oggimage(audiofile, vec);
+                                this->call_audio_oggimage(audiofile, vec);
                             }
                             break;
     }
@@ -5774,31 +5774,31 @@ bool Audio::readID3V1Tag() {
         else { AUDIO_INFO("ID3 Version 1.1"); }
         if(strlen(title)) {
             sprintf(m_chbuf, "Title: %s", title);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(artist)) {
             sprintf(m_chbuf, "Artist: %s", artist);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(album)) {
             sprintf(m_chbuf, "Album: %s", album);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(year)) {
             sprintf(m_chbuf, "Year: %s", year);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(comment)) {
             sprintf(m_chbuf, "Comment: %s", comment);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(zeroByte == 0) {
             sprintf(m_chbuf, "Track Number: %d", track);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(genre < 192) {
             sprintf(m_chbuf, "Genre: %d", genre);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         } //[1]
         return true;
     }
@@ -5825,19 +5825,19 @@ bool Audio::readID3V1Tag() {
         // six bytes "end-time",   the end of the music as mmm:ss
         if(strlen(title)) {
             sprintf(m_chbuf, "Title: %s", title);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(artist)) {
             sprintf(m_chbuf, "Artist: %s", artist);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(album)) {
             sprintf(m_chbuf, "Album: %s", album);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         if(strlen(genre)) {
             sprintf(m_chbuf, "Genre: %s", genre);
-            if(audio_id3data) audio_id3data(m_chbuf);
+            this->call_audio_id3data(m_chbuf);
         }
         return true;
     }
@@ -5986,7 +5986,7 @@ void Audio::seek_m4a_ilst() {    // ilist - item list atom, contains the metadat
             if(i == 10) sprintf(m_chbuf, "Album Artist: %s", value);
             if(i == 11) sprintf(m_chbuf, "Types of: %s", value);
             if(m_chbuf[0] != 0) {
-                if(audio_id3data) audio_id3data(m_chbuf);
+                this->call_audio_id3data(m_chbuf);
             }
         }
     }
@@ -6343,4 +6343,145 @@ void Audio::performAudioTask() {
         vTaskDelay(20 / portTICK_PERIOD_MS); playChunk();} // I2S buffer full
     playAudioData();
     xSemaphoreGive(mutex_playAudioData);
+}
+
+void Audio::call_audio_info(const char* info) {
+    if (audio_info) audio_info(info);
+
+    if(this->audioInfoCallback) {
+        std::string s(info);
+        this->audioInfoCallback(s);
+    }
+}
+
+void Audio::call_audio_id3data(const char* info) {
+    if (audio_id3data) audio_id3data(info);
+
+    if (this->id3DataCallback) {
+        std::string s(info);
+        this->id3DataCallback(s);
+    }
+}
+
+void Audio::call_audio_id3image(File& file, const size_t pos, const size_t size) {
+    if (audio_id3image) audio_id3image(file, pos, size);
+
+    if (this->id3ImageCallback) {
+        this->id3ImageCallback(file, pos, size);
+    }
+}
+
+void Audio::call_audio_oggimage(File& file, std::vector<uint32_t> v) {
+    if (audio_oggimage) audio_oggimage(file, v);
+
+    if (this->oggImageCallback) {
+        this->oggImageCallback(file, v);
+    }
+}
+
+void Audio::call_audio_id3lyrics(File& file, const size_t pos, const size_t size) {
+    if (audio_id3lyrics) audio_id3lyrics(file, pos, size);
+
+    if (this->id3LyricsCallback) {
+        this->id3LyricsCallback(file, pos, size);
+    }
+}
+
+void Audio::call_audio_eof_mp3(const char* info) {
+    if (audio_eof_mp3) audio_eof_mp3(info)
+
+    if (this->mp3EOFCallback) {
+        std::string s(info);
+        this->mp3EOFCallback(s);
+    }
+}
+
+void Audio::call_audio_showstreamtitle(const char* info) {
+    if (audio_showstreamtitle) audio_showstreamtitle(info);
+
+    if (this->streamTitleCallback) {
+        std::string s(info);
+        this->streamTitleCallback(s);
+    }
+}
+
+void Audio::call_audio_showstation(const char* info) {
+    if (audio_showstation) audio_showstation(info);
+
+    if (this->stationNameCallback) {
+        std::string s(info);
+        this->stationNameCallback(s);
+    }
+}
+
+void Audio::call_audio_bitrate(const char* info) {
+    if (audio_bitrate) audio_bitrate(info);
+
+    if (this->bitrateChangeCallback) {
+        std::string s(info);
+        this->bitrateChangeCallback(s);
+    }
+}
+
+void Audio::call_audio_commercial(const char* info) {
+    if (audio_commercial) audio_commercial(info);
+
+    if (this->commercialInfoCallback) {
+        std::string s(info);
+        this->commercialInfoCallback(s);
+    }
+}
+
+void Audio::call_audio_icyurl(const char* info) {
+    if (audio_icyurl) audio_icyurl(info);
+
+    if (this->icyUrlCallback) {
+        std::string s(info);
+        this->icyUrlCallback(s);
+    }
+}
+
+void Audio::call_audio_icylogo(const char* info) {
+    if (audio_icylogo) audio_icylogo(info);
+
+    if (this->icyLogoCallback) {
+        std::string s(info);
+        this->icyLogoCallback(s);
+    }
+}
+
+void Audio::call_audio_icydescription(const char* info) {
+    if (audio_icydescription) audio_icydescription(info);
+
+    if (this->icyDescriptionCallback) {
+        std::string s(info);
+        this->icyDescriptionCallback(s);
+    }
+}
+
+void Audio::call_audio_lasthost(const char* info) {
+    if (audio_lasthost) audio_lasthost(info);
+
+    if (this->lastHostCallback) {
+        std::string s(info);
+        this->lastHostCallback(s);
+    }
+}
+
+void Audio::call_audio_eof_speech(const char* info) {
+    if (audio_eof_speech) audio_eof_speech(info);
+
+    if (this->speechEOFCallback) {
+        std::string s(info);
+        this->speechEOFCallback(s);
+    }
+}
+
+void Audio::call_audio_eof_stream(const char* info) {
+    if (audio_eof_stream) audio_eof_stream(info);
+
+    if (this->streamEOFCallback) {
+        std::string s(info);
+        this->streamEOFCallback(s);
+    }
 }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -22,6 +22,7 @@
 #include <FS.h>
 #include <FFat.h>
 #include <atomic>
+#include <functional>
 
 #if ESP_IDF_VERSION_MAJOR == 5
 #include <driver/i2s_std.h>
@@ -176,6 +177,58 @@ public:
     int getCodec() {return m_codec;}
     const char *getCodecname() {return codecname[m_codec];}
     void unicode2utf8(char* buff, uint32_t len);
+
+    void setAudioInfoCallback(std::function<void(std::string &info)> callback) { this->audioInfoCallback = callback }                               // audio_info
+    void setID3DataCallback(std::function<void(std::string &info)> callback) { this->id3DataCallback = callback }                                   // audio_id3data
+    void setID3ImageCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3ImageCallback = callback }   // audio_id3image
+    void setOGGImageCallback(std::function<void(File& file, std::vector<uint32_t> v)> callback) { this->oggImageCallback = callback }               // audio_oggimage
+    void setID3LyricsCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3LyricsCallback = callback } // audio_id3lyrics
+    void setMP3EOFCallback(std::function<void(std::string &info)> callback) { this->mp3EOFCallback = callback }                                     // audio_eof_mp3
+    void setStreamTitleCallback(std::function<void(std::string &info)> callback) { this->streamTitleCallback = callback }                           // audio_showstreamtitle
+    void setStationNameCallback(std::function<void(std::string &info)> callback) { this->stationNameCallback = callback }                           // audio_showstation
+    void setBitrateChangeCallback(std::function<void(std::string &info)> callback) { this->bitrateChangeCallback = callback }                       // audio_bitrate
+    void setCommercialInfoCallback(std::function<void(std::string &info)> callback) { this->commercialInfoCallback = callback }                     // audio_commercial
+    void setICYUrlCallback(std::function<void(std::string &info)> callback) { this->icyUrlCallback = callback }                                     // audio_icyurl
+    void setICYLogoCallback(std::function<void(std::string &info)> callback) { this->icyLogoCallback = callback }                                   // audio_icylogo
+    void setICYDescriptionCallback(std::function<void(std::string &info)> callback) { this->icyDescriptionCallback = callback }                     // audio_icydescription
+    void setLastHostCallback(std::function<void(std::string &info)> callback) { this->lastHostCallback = callback }                                 // audio_lasthost
+    void setSpeechEOFCallback(std::function<void(std::string &info)> callback) { this->speechEOFCallback = callback }                               // audio_eof_speech
+    void setStreamEOFCallback(std::function<void(std::string &info)> callback) { this->streamEOFCallback = callback }                               // audio_eof_stream
+
+private:
+    std::function<void(std::string &info)> audioInfoCallback;
+    std::function<void(std::string &info)> id3DataCallback;
+    std::function<void(File& file, const size_t pos, const size_t size)> id3ImageCallback;
+    std::function<void(File& file, std::vector<uint32_t> v)> oggImageCallback;
+    std::function<void(File& file, const size_t pos, const size_t size)> id3LyricsCallback;
+    std::function<void(std::string &info)> mp3EOFCallback;
+    std::function<void(std::string &info)> streamTitleCallback;
+    std::function<void(std::string &info)> stationNameCallback;
+    std::function<void(std::string &info)> bitrateChangeCallback;
+    std::function<void(std::string &info)> commercialInfoCallback;
+    std::function<void(std::string &info)> icyUrlCallback;
+    std::function<void(std::string &info)> icyLogoCallback;
+    std::function<void(std::string &info)> icyDescriptionCallback;
+    std::function<void(std::string &info)> lastHostCallback;
+    std::function<void(std::string &info)> speechEOFCallback;
+    std::function<void(std::string &info)> streamEOFCallback;
+
+    void call_audio_info(const char* info);
+    void call_audio_id3data(const char* info);
+    void call_audio_id3image(File& file, const size_t pos, const size_t size);
+    void call_audio_oggimage(File& file, std::vector<uint32_t> v);
+    void call_audio_id3lyrics(File& file, const size_t pos, const size_t size);
+    void call_audio_eof_mp3(const char* info);
+    void call_audio_showstreamtitle(const char* info);
+    void call_audio_showstation(const char* info);
+    void call_audio_bitrate(const char* info);
+    void call_audio_commercial(const char* info);
+    void call_audio_icyurl(const char* info);
+    void call_audio_icylogo(const char* info);
+    void call_audio_icydescription(const char* info);
+    void call_audio_lasthost(const char* info);
+    void call_audio_eof_speech(const char* info);
+    void call_audio_eof_stream(const char* info);
 
 private:
 

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -178,40 +178,40 @@ public:
     const char *getCodecname() {return codecname[m_codec];}
     void unicode2utf8(char* buff, uint32_t len);
 
-    void setAudioInfoCallback(std::function<void(std::string &info)> callback) { this->audioInfoCallback = callback }                               // audio_info
-    void setID3DataCallback(std::function<void(std::string &info)> callback) { this->id3DataCallback = callback }                                   // audio_id3data
+    void setAudioInfoCallback(std::function<void(const char* info)> callback) { this->audioInfoCallback = callback }                               // audio_info
+    void setID3DataCallback(std::function<void(const char* info)> callback) { this->id3DataCallback = callback }                                   // audio_id3data
     void setID3ImageCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3ImageCallback = callback }   // audio_id3image
     void setOGGImageCallback(std::function<void(File& file, std::vector<uint32_t> v)> callback) { this->oggImageCallback = callback }               // audio_oggimage
     void setID3LyricsCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3LyricsCallback = callback } // audio_id3lyrics
-    void setMP3EOFCallback(std::function<void(std::string &info)> callback) { this->mp3EOFCallback = callback }                                     // audio_eof_mp3
-    void setStreamTitleCallback(std::function<void(std::string &info)> callback) { this->streamTitleCallback = callback }                           // audio_showstreamtitle
-    void setStationNameCallback(std::function<void(std::string &info)> callback) { this->stationNameCallback = callback }                           // audio_showstation
-    void setBitrateChangeCallback(std::function<void(std::string &info)> callback) { this->bitrateChangeCallback = callback }                       // audio_bitrate
-    void setCommercialInfoCallback(std::function<void(std::string &info)> callback) { this->commercialInfoCallback = callback }                     // audio_commercial
-    void setICYUrlCallback(std::function<void(std::string &info)> callback) { this->icyUrlCallback = callback }                                     // audio_icyurl
-    void setICYLogoCallback(std::function<void(std::string &info)> callback) { this->icyLogoCallback = callback }                                   // audio_icylogo
-    void setICYDescriptionCallback(std::function<void(std::string &info)> callback) { this->icyDescriptionCallback = callback }                     // audio_icydescription
-    void setLastHostCallback(std::function<void(std::string &info)> callback) { this->lastHostCallback = callback }                                 // audio_lasthost
-    void setSpeechEOFCallback(std::function<void(std::string &info)> callback) { this->speechEOFCallback = callback }                               // audio_eof_speech
-    void setStreamEOFCallback(std::function<void(std::string &info)> callback) { this->streamEOFCallback = callback }                               // audio_eof_stream
+    void setMP3EOFCallback(std::function<void(const char* info)> callback) { this->mp3EOFCallback = callback }                                     // audio_eof_mp3
+    void setStreamTitleCallback(std::function<void(const char* info)> callback) { this->streamTitleCallback = callback }                           // audio_showstreamtitle
+    void setStationNameCallback(std::function<void(const char* info)> callback) { this->stationNameCallback = callback }                           // audio_showstation
+    void setBitrateChangeCallback(std::function<void(const char* info)> callback) { this->bitrateChangeCallback = callback }                       // audio_bitrate
+    void setCommercialInfoCallback(std::function<void(const char* info)> callback) { this->commercialInfoCallback = callback }                     // audio_commercial
+    void setICYUrlCallback(std::function<void(const char* info)> callback) { this->icyUrlCallback = callback }                                     // audio_icyurl
+    void setICYLogoCallback(std::function<void(const char* info)> callback) { this->icyLogoCallback = callback }                                   // audio_icylogo
+    void setICYDescriptionCallback(std::function<void(const char* info)> callback) { this->icyDescriptionCallback = callback }                     // audio_icydescription
+    void setLastHostCallback(std::function<void(const char* info)> callback) { this->lastHostCallback = callback }                                 // audio_lasthost
+    void setSpeechEOFCallback(std::function<void(const char* info)> callback) { this->speechEOFCallback = callback }                               // audio_eof_speech
+    void setStreamEOFCallback(std::function<void(const char* info)> callback) { this->streamEOFCallback = callback }                               // audio_eof_stream
 
 private:
-    std::function<void(std::string &info)> audioInfoCallback;
-    std::function<void(std::string &info)> id3DataCallback;
+    std::function<void(const char* info)> audioInfoCallback;
+    std::function<void(const char* info)> id3DataCallback;
     std::function<void(File& file, const size_t pos, const size_t size)> id3ImageCallback;
     std::function<void(File& file, std::vector<uint32_t> v)> oggImageCallback;
     std::function<void(File& file, const size_t pos, const size_t size)> id3LyricsCallback;
-    std::function<void(std::string &info)> mp3EOFCallback;
-    std::function<void(std::string &info)> streamTitleCallback;
-    std::function<void(std::string &info)> stationNameCallback;
-    std::function<void(std::string &info)> bitrateChangeCallback;
-    std::function<void(std::string &info)> commercialInfoCallback;
-    std::function<void(std::string &info)> icyUrlCallback;
-    std::function<void(std::string &info)> icyLogoCallback;
-    std::function<void(std::string &info)> icyDescriptionCallback;
-    std::function<void(std::string &info)> lastHostCallback;
-    std::function<void(std::string &info)> speechEOFCallback;
-    std::function<void(std::string &info)> streamEOFCallback;
+    std::function<void(const char* info)> mp3EOFCallback;
+    std::function<void(const char* info)> streamTitleCallback;
+    std::function<void(const char* info)> stationNameCallback;
+    std::function<void(const char* info)> bitrateChangeCallback;
+    std::function<void(const char* info)> commercialInfoCallback;
+    std::function<void(const char* info)> icyUrlCallback;
+    std::function<void(const char* info)> icyLogoCallback;
+    std::function<void(const char* info)> icyDescriptionCallback;
+    std::function<void(const char* info)> lastHostCallback;
+    std::function<void(const char* info)> speechEOFCallback;
+    std::function<void(const char* info)> streamEOFCallback;
 
     void call_audio_info(const char* info);
     void call_audio_id3data(const char* info);

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -178,22 +178,22 @@ public:
     const char *getCodecname() {return codecname[m_codec];}
     void unicode2utf8(char* buff, uint32_t len);
 
-    void setAudioInfoCallback(std::function<void(const char* info)> callback) { this->audioInfoCallback = callback }                               // audio_info
-    void setID3DataCallback(std::function<void(const char* info)> callback) { this->id3DataCallback = callback }                                   // audio_id3data
+    void setAudioInfoCallback(std::function<void(const char* info)> callback) { this->audioInfoCallback = callback }                                // audio_info
+    void setID3DataCallback(std::function<void(const char* info)> callback) { this->id3DataCallback = callback }                                    // audio_id3data
     void setID3ImageCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3ImageCallback = callback }   // audio_id3image
     void setOGGImageCallback(std::function<void(File& file, std::vector<uint32_t> v)> callback) { this->oggImageCallback = callback }               // audio_oggimage
     void setID3LyricsCallback(std::function<void(File& file, const size_t pos, const size_t size)> callback) { this->id3LyricsCallback = callback } // audio_id3lyrics
-    void setMP3EOFCallback(std::function<void(const char* info)> callback) { this->mp3EOFCallback = callback }                                     // audio_eof_mp3
-    void setStreamTitleCallback(std::function<void(const char* info)> callback) { this->streamTitleCallback = callback }                           // audio_showstreamtitle
-    void setStationNameCallback(std::function<void(const char* info)> callback) { this->stationNameCallback = callback }                           // audio_showstation
-    void setBitrateChangeCallback(std::function<void(const char* info)> callback) { this->bitrateChangeCallback = callback }                       // audio_bitrate
-    void setCommercialInfoCallback(std::function<void(const char* info)> callback) { this->commercialInfoCallback = callback }                     // audio_commercial
-    void setICYUrlCallback(std::function<void(const char* info)> callback) { this->icyUrlCallback = callback }                                     // audio_icyurl
-    void setICYLogoCallback(std::function<void(const char* info)> callback) { this->icyLogoCallback = callback }                                   // audio_icylogo
-    void setICYDescriptionCallback(std::function<void(const char* info)> callback) { this->icyDescriptionCallback = callback }                     // audio_icydescription
-    void setLastHostCallback(std::function<void(const char* info)> callback) { this->lastHostCallback = callback }                                 // audio_lasthost
-    void setSpeechEOFCallback(std::function<void(const char* info)> callback) { this->speechEOFCallback = callback }                               // audio_eof_speech
-    void setStreamEOFCallback(std::function<void(const char* info)> callback) { this->streamEOFCallback = callback }                               // audio_eof_stream
+    void setMP3EOFCallback(std::function<void(const char* info)> callback) { this->mp3EOFCallback = callback }                                      // audio_eof_mp3
+    void setStreamTitleCallback(std::function<void(const char* info)> callback) { this->streamTitleCallback = callback }                            // audio_showstreamtitle
+    void setStationNameCallback(std::function<void(const char* info)> callback) { this->stationNameCallback = callback }                            // audio_showstation
+    void setBitrateChangeCallback(std::function<void(const char* info)> callback) { this->bitrateChangeCallback = callback }                        // audio_bitrate
+    void setCommercialInfoCallback(std::function<void(const char* info)> callback) { this->commercialInfoCallback = callback }                      // audio_commercial
+    void setICYUrlCallback(std::function<void(const char* info)> callback) { this->icyUrlCallback = callback }                                      // audio_icyurl
+    void setICYLogoCallback(std::function<void(const char* info)> callback) { this->icyLogoCallback = callback }                                    // audio_icylogo
+    void setICYDescriptionCallback(std::function<void(const char* info)> callback) { this->icyDescriptionCallback = callback }                      // audio_icydescription
+    void setLastHostCallback(std::function<void(const char* info)> callback) { this->lastHostCallback = callback }                                  // audio_lasthost
+    void setSpeechEOFCallback(std::function<void(const char* info)> callback) { this->speechEOFCallback = callback }                                // audio_eof_speech
+    void setStreamEOFCallback(std::function<void(const char* info)> callback) { this->streamEOFCallback = callback }                                // audio_eof_stream
 
 private:
     std::function<void(const char* info)> audioInfoCallback;


### PR DESCRIPTION
add C++-Style callbacks

example:
```cpp
#include "Arduino.h"
#include "WiFi.h"
#include "Audio.h"


// Digital I/O used
#define I2S_DOUT      25
#define I2S_BCLK      27
#define I2S_LRC       26

Audio audio;

String ssid =     "*******";
String password = "*******";

void setup() {
    Serial.begin(115200);

    WiFi.disconnect();
    WiFi.mode(WIFI_STA);
    WiFi.begin(ssid.c_str(), password.c_str());
    while (WiFi.status() != WL_CONNECTED) delay(1500);

    audio.setPinout(I2S_BCLK, I2S_LRC, I2S_DOUT);
    audio.setVolume(21); // default 0...21

    audio.connecttohost("http://stream.antennethueringen.de/live/aac-64/stream.antennethueringen.de/");

    // optional / C++-Style callbacks
    // all audio_* C-Style callbacks are supported
    audio.setAudioInfoCallback(audio_info) // function
    audio.setID3DataCallback([](const char* info){ 
        Serial.print("id3data "); Serial.println(info); 
    }); // lambda
    // ...
}

void loop()
{
    audio.loop();
}

// optional / C-Style callbacks
void audio_info(const char *info){
    Serial.print("info        "); Serial.println(info);
}
void audio_id3data(const char *info){  //id3 metadata
    Serial.print("id3data     ");Serial.println(info);
}
// ...
```

